### PR TITLE
feat: upgrade Rspack from 1.x to v2

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -40,6 +40,7 @@ export default defineConfig({
           { text: '配置 PostCSS', link: '/guide/config-postcss' },
           { text: '环境变量', link: '/guide/env-variables' },
           { text: '使用 HTTPS 进行本地开发', link: '/guide/https' },
+          { text: '升级到 Rspack v2', link: '/guide/upgrade-v2' },
         ]
       }],
       '/config/': [

--- a/docs/docs/guide/rspack.md
+++ b/docs/docs/guide/rspack.md
@@ -1,13 +1,19 @@
 # 使用 Rspack
 
 :::tip Rspack 介绍
-[Rspack](https://rspack.dev/zh/index) 是一个基于 Rust 编写的高性能 JavaScript 打包工具， 它提供对 webpack 生态良好的兼容性，能够无缝替换 webpack， 并提供闪电般的构建速度。
+[Rspack](https://rspack.rs/zh/) 是一个基于 Rust 编写的高性能 JavaScript 打包工具， 它提供对 webpack 生态良好的兼容性，能够无缝替换 webpack， 并提供闪电般的构建速度。
 
 相较于 webpack，Rspack 的构建性能有明显提升，除了 Rust 带来的语言优势，这也来自于它的并行架构和增量编译等特性。经过 benchmark 验证，Rspack 可以带来 5 ～ 10 倍编译性能的提升。
 :::
 
+:::warning Node.js 版本要求
+KMI 当前版本基于 Rspack 2.0，要求 Node.js **>= 20.19.0** 或 **>= 22.12.0**。如果你使用的 Node.js 版本低于要求，请先升级 Node.js。
+:::
+
 **Kmi 提供开箱即用的 Rspack 支持**，你可以在成熟的 Webpack 和更快的 Rspack 之间进行切换。
 这篇文档会向你介绍如何在 Kmi 中开启 Rspack 构建模式。
+
+如果你正在从旧版本升级，请参考 [升级到 Rspack v2](/guide/upgrade-v2)。
 
 ## 开启 Rspack 构建
 
@@ -30,7 +36,7 @@ export default defineConfig({
 
 在使用 Rspack 前，你需要了解以下事项：
 
-- Rspack 能够兼容大部分 webpack 插件和几乎所有的 loaders，但仍有少数 webpack 插件暂时无法使用，详见 [Plugin 兼容](https://rspack.dev/zh/guide/compatibility/plugin)。
+- Rspack 能够兼容大部分 webpack 插件和几乎所有的 loaders，但仍有少数 webpack 插件暂时无法使用，详见 [Plugin 兼容](https://rspack.rs/zh/guide/compatibility/plugin)。
 - Rspack 默认基于 SWC 进行代码编译和压缩， 如项目使用了 额外的 babel 插件, 请检查是否有替代的 swc 插件 或者通过 `useBabel` 启用 babel 支持。
 
 ## 配置迁移
@@ -135,7 +141,7 @@ export default defineConfig({
 ```
 
 同时，你需要尽快联系第三方依赖的开发者来修复相应的问题。
-你可以查看 Rspack 的文档来了解 [module.parser.javascript.exportsPresence](https://rspack.dev/zh/config/module#moduleparserjavascriptexportspresence) 的更多细节。
+你可以查看 Rspack 的文档来了解 [module.parser.javascript.exportsPresence](https://rspack.rs/zh/config/module#moduleparserjavascriptexportspresence) 的更多细节。
 
 ### Less 配置不支持
 less-loader 配置、不支持函数配置。在新版本的 rspack 支持中 less 编译我们使用了 `piscina` 的 workers 并行编译 less 文件, 这可以加速编译过程。但是受限于 workers less 不在支持直接传函数、如需需要可通过一下配置切换到默认 less 支持

--- a/docs/docs/guide/upgrade-v2.md
+++ b/docs/docs/guide/upgrade-v2.md
@@ -104,6 +104,28 @@ module.identifier()
 
 - 第三个参数从 `items: string[]` 变为结构化的 `info` 对象（`{ builtModules, moduleIdentifier }`）
 
+### output.library\* 系列 API 迁移
+
+Rspack v2 将多个 `output.*` 选项合并到了 `output.library` 子对象中：
+
+| v1 配置 | v2 配置 |
+|---------|---------|
+| `output.libraryTarget` | `output.library.type` |
+| `output.libraryExport` | `output.library.export` |
+| `output.umdNamedDefine` | `output.library.umdNamedDefine` |
+| `output.auxiliaryComment` | `output.library.auxiliaryComment` |
+
+KMI 内置了兼容层，会自动将旧 API 转换为新 API（如 qiankun 插件使用的 `libraryTarget`）。但如果你在自定义 `chainWebpack` 中直接使用了这些旧选项，建议迁移：
+
+```ts
+// v1 写法（兼容层会自动转换，但建议迁移）
+config.output.libraryTarget('umd')
+config.output.libraryExport('MyLib')
+
+// v2 写法
+config.output.library({ type: 'umd', export: 'MyLib' })
+```
+
 ### `optimization.removeAvailableModules` 移除
 
 此配置在 Rspack 中无实际效果，v2 已直接移除。如果你的代码中显式设置了它，可以安全删除。

--- a/docs/docs/guide/upgrade-v2.md
+++ b/docs/docs/guide/upgrade-v2.md
@@ -1,0 +1,131 @@
+# 升级到 Rspack v2
+
+KMI 在新版本中将底层构建引擎从 Rspack 1.x 升级到了 Rspack 2.0。这篇文档会介绍此次升级带来的变化，以及你可能需要做的调整。
+
+## 概览
+
+Rspack 2.0 是一次重大升级，带来了性能优化、更现代的 API 设计，以及若干破坏性变更。KMI 已将绝大多数变更封装在内部，**对于使用标准 KMI 配置的开发者来说，此次升级几乎是无感的**。
+
+## Node.js 版本要求
+
+Rspack 2.0 要求最低 Node.js 版本为 **20.19.0+** 或 **22.12.0+**，不再支持 Node.js 16 和 18。
+
+如果你当前使用较低版本的 Node.js，请在升级 KMI 之前先升级 Node.js：
+
+```bash
+node -v  # 确认版本 >= 20.19.0
+```
+
+## 升级步骤
+
+1. **升级 Node.js** 到 `>= 20.19.0`
+2. **升级 KMI 版本** — 新版本已包含 `@rspack/core` v2 及相关依赖
+3. **重新安装依赖**：
+
+```bash
+npm install   # 或 pnpm install / yarn install
+```
+
+## 用户配置兼容性
+
+以下 KMI 配置项在 Rspack v2 中**完全向后兼容**，你无需修改任何代码：
+
+| 配置项 | 说明 |
+|--------|------|
+| `transformImport` | 内部实现由 `rspackExperiments.import` 迁移至 `transformImport` 选项，用户配置无需变更 |
+| `rspack.incremental` | 内部由 `experiments.incremental` 提升为顶层 `incremental` 配置，用户配置无需变更 |
+| `rspack.lazyCompilation` | 内部由 `experiments.lazyCompilation` 提升为顶层 `lazyCompilation` 配置，用户配置无需变更 |
+| `esm` | 内部由 `experiments.outputModule` 迁移至 `output.module`，用户配置无需变更 |
+| `javascriptExportsPresence` | 行为不变，配置为 `false` 时降级为 `warn`，否则为 `error` |
+| `rspack.useBabel` | 无变化，继续兼容 |
+
+## 自定义 chainWebpack / 插件迁移
+
+如果你在项目中使用 `chainWebpack` 直接操作 Rspack 底层配置，或者编写了自定义 Rspack 插件，需要注意以下变更：
+
+### experiments 选项迁移
+
+Rspack v2 将 `experiments` 中的多个实验性选项移到了顶层配置或直接移除：
+
+| v1 配置 | v2 变化 |
+|---------|---------|
+| `experiments.lazyCompilation` | 移至顶层 `lazyCompilation` |
+| `experiments.incremental` | 移至顶层 `incremental` |
+| `experiments.outputModule` | 移至 `output.module` |
+| `experiments.topLevelAwait` | 已稳定，ESM 模块默认启用 |
+| `experiments.css` | 已移除，CSS 处理能力默认可用 |
+| `experiments.rspackFuture` | 已移除，其中 `bundlerInfo` 移至 `output.bundlerInfo` |
+
+如果你在 `chainWebpack` 中有类似以下代码：
+
+```ts
+// v1 写法（不再生效）
+chainWebpack(config) {
+  config.experiments({
+    ...config.toConfig().experiments,
+    lazyCompilation: { ... }
+  })
+}
+```
+
+建议改用 KMI 提供的 `rspack.lazyCompilation` 配置项，或直接使用顶层 API：
+
+```ts
+// 推荐：使用 KMI 配置
+export default defineConfig({
+  rspack: {
+    lazyCompilation: true
+  }
+})
+
+// 或者在 chainWebpack 中使用 v2 顶层 API
+chainWebpack(config) {
+  config.set('lazyCompilation', { ... })
+}
+```
+
+### Runtime Module API 变更
+
+Rspack v2 移除了 Runtime module 的 `constructorName` 和 `moduleIdentifier` 属性。自定义插件中应改用标准 API：
+
+```ts
+// v1 写法（不再生效）
+module.constructorName
+module.moduleIdentifier
+
+// v2 写法
+module.constructor.name
+module.identifier()
+```
+
+### ProgressPlugin 回调变更
+
+如果你使用自定义的 `chainWebpack` 注册了 [ProgressPlugin](https://rspack.rs/plugins/webpack/progress-plugin)，注意回调参数已变更：
+
+- 第三个参数从 `items: string[]` 变为结构化的 `info` 对象（`{ builtModules, moduleIdentifier }`）
+
+### `optimization.removeAvailableModules` 移除
+
+此配置在 Rspack 中无实际效果，v2 已直接移除。如果你的代码中显式设置了它，可以安全删除。
+
+### `profile` 配置移除
+
+顶层 `profile` 和 `stats.profile` 配置已移除。如需性能分析，推荐使用 [Rsdoctor](https://rspack.rs/guide/optimization/use-rsdoctor)。
+
+## 其他内部变更
+
+以下变更是 KMI 框架内部的调整，对用户侧完全透明，仅作参考：
+
+- `@rspack/core` 升级为纯 ESM 包，Node.js 20.19+ 通过 `require(esm)` 原生支持，不影响使用
+- `@rspack/plugin-react-refresh` 升级至 v2，React 热更新行为无变化
+- `@rspack/lite-tapable` 升级至 1.1.0
+- `experiments.nativeWatcher` 已移除（文件监听已稳定，默认启用）
+
+## 遇到问题？
+
+如果升级后遇到问题，请先检查：
+
+- Node.js 版本是否满足 `>= 20.19.0`
+- 依赖是否正确安装（删除 `node_modules` 和 lockfile 后重新 `pnpm install`）
+
+如果问题仍然存在，请在 [GitHub Issues](https://github.com/kmijs/kmi/issues) 提交反馈。

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "packageManager": "pnpm@8.15.8",
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=20.19.0",
     "pnpm": ">=8.0.0"
   },
   "pnpm": {

--- a/packages/bundler-rspack/package.json
+++ b/packages/bundler-rspack/package.json
@@ -42,7 +42,7 @@
     "upath": "2.0.1"
   },
   "engines": {
-    "node": "^14.18.0 || >=16.10.0"
+    "node": ">=20.19.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/bundler-rspack/src/bundler.test.ts
+++ b/packages/bundler-rspack/src/bundler.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest'
+
+describe('ProgressPlugin v2 callback', () => {
+  test('info should be an object with builtModules (not string[])', () => {
+    const progresses: any[] = []
+    const progress = {
+      percent: 0,
+      status: 'waiting',
+      details: null as any,
+    }
+    progresses.push(progress)
+
+    const info = { builtModules: 42, moduleIdentifier: '/path/to/module.ts' }
+
+    progress.percent = 0.5
+    progress.status = 'compiling'
+    progress.details = info
+
+    expect(progress.percent).toBe(0.5)
+    expect(progress.status).toBe('compiling')
+    expect(progress.details).toEqual(info)
+    expect(progress.details.builtModules).toBe(42)
+    expect(Array.isArray(progress.details)).toBe(false)
+  })
+
+  test('info.builtModules is accessible as number', () => {
+    const info = { builtModules: 42 }
+    expect(typeof info.builtModules).toBe('number')
+  })
+})

--- a/packages/bundler-rspack/src/bundler.ts
+++ b/packages/bundler-rspack/src/bundler.ts
@@ -93,17 +93,21 @@ export class RspackBundler extends BaseBundler<IConfig, IOpts> {
     if (env === Env.development && opts.onProgress) {
       bundlerConfigs.forEach((config) => {
         const progresses: any[] = []
-        const progress = {
+        const progress: {
+          percent: number
+          status: string
+          details: any
+        } = {
           percent: 0,
           status: 'waiting',
-          details: [],
+          details: null,
         }
         progresses.push(progress)
         config.plugins!.push(
-          new rspack.ProgressPlugin((percent, msg, ...details) => {
+          new rspack.ProgressPlugin((percent, msg, info) => {
             progress.percent = percent
             progress.status = msg
-            ;(progress.details as string[]) = details
+            progress.details = info
             opts.onProgress!({ progresses })
           }),
         )

--- a/packages/bundler-rspack/src/config/swcRules.ts
+++ b/packages/bundler-rspack/src/config/swcRules.ts
@@ -73,7 +73,10 @@ export async function addSwcRules(opts: IApplyOpts) {
   }
 
   // 用户配置
-  const mergedSwcConfig = deepmerge(swcConfig, userConfig.swc || {})
+  const mergedSwcConfig = deepmerge<any, any>(
+    swcConfig,
+    userConfig.swc || {},
+  ) as SwcLoaderOptions
 
   if (mergedSwcConfig.jsc?.externalHelpers) {
     config.resolve.alias.set(

--- a/packages/bundler-rspack/src/plugins/RuntimePublicPathPlugin.ts
+++ b/packages/bundler-rspack/src/plugins/RuntimePublicPathPlugin.ts
@@ -9,7 +9,7 @@ export class RuntimePublicPathPlugin {
       compilation.hooks.runtimeModule.tap(PLUGIN_NAME, (module) => {
         // The hook to get the public path ('__webpack_require__.p')
         // https://github.com/webpack/webpack/blob/master/lib/runtime/PublicPathRuntimeModule.js
-        if (module.constructorName === 'PublicPathRuntimeModule') {
+        if (module.constructor.name === 'PublicPathRuntimeModule') {
           if (module.source) {
             // If current public path is handled by mini-css-extract-plugin, skip it
             const originSource = module.source?.source.toString('utf-8')

--- a/packages/bundler-shared-config/package.json
+++ b/packages/bundler-shared-config/package.json
@@ -40,7 +40,7 @@
     "node-polyfill-webpack-plugin": "4.1.0"
   },
   "engines": {
-    "node": ">=16.10.0"
+    "node": ">=20.19.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/bundler-shared-config/src/config/__snapshots__/basic.test.ts.snap
+++ b/packages/bundler-shared-config/src/config/__snapshots__/basic.test.ts.snap
@@ -4,10 +4,6 @@ exports[`output > normal 1`] = `
 "{
   mode: 'production',
   stats: 'none',
-  experiments: {
-    topLevelAwait: true,
-    outputModule: false
-  },
   infrastructureLogging: {
     level: 'warn'
   },
@@ -44,10 +40,6 @@ exports[`output > 自定义 extensions 1`] = `
 "{
   mode: 'production',
   stats: 'none',
-  experiments: {
-    topLevelAwait: true,
-    outputModule: false
-  },
   infrastructureLogging: {
     level: 'warn'
   },

--- a/packages/bundler-shared-config/src/config/basic.ts
+++ b/packages/bundler-shared-config/src/config/basic.ts
@@ -4,7 +4,7 @@ import type { SharedConfigOptions } from '../types'
 import { Env } from '../types'
 
 export function applyBasic(opts: SharedConfigOptions) {
-  const { name, config, userConfig, bundler, bundlerType } = opts
+  const { name, config, userConfig, bundler } = opts
 
   const isDev = opts.env === Env.development
 
@@ -71,12 +71,10 @@ export function applyBasic(opts: SharedConfigOptions) {
   // externals
   config.externals(userConfig.externals || [])
 
-  // experiments
-  config.experiments({
-    topLevelAwait: true,
-    outputModule: !!userConfig.esm,
-    ...(bundlerType === 'rspack' ? { nativeWatcher: true } : {}),
-  })
+  // experiments.topLevelAwait, outputModule, nativeWatcher removed in Rspack v2
+  if (userConfig.esm) {
+    config.output.module(true)
+  }
 
   config.infrastructureLogging({
     level: 'warn',

--- a/packages/bundler-shared/compiled/rspack-chain/types/index.d.ts
+++ b/packages/bundler-shared/compiled/rspack-chain/types/index.d.ts
@@ -95,7 +95,7 @@ declare class Config extends __Config.ChainedMap<void> {
   ignoreWarnings(value: RspackConfig['ignoreWarnings']): this;
   loader(value: RspackConfig['loader']): this;
   parallelism(value: RspackConfig['parallelism']): this;
-  profile(value: RspackConfig['profile']): this;
+  // profile removed in Rspack v2
   recordsPath(value: RspackConfig['recordsPath']): this;
   recordsInputPath(value: RspackConfig['recordsInputPath']): this;
   recordsOutputPath(value: RspackConfig['recordsOutputPath']): this;
@@ -449,9 +449,7 @@ declare namespace Config {
     chunkIds(value: RspackOptimization['chunkIds']): this;
     nodeEnv(value: RspackOptimization['nodeEnv']): this;
     mangleWasmImports(value: RspackOptimization['mangleWasmImports']): this;
-    removeAvailableModules(
-      value: RspackOptimization['removeAvailableModules'],
-    ): this;
+    // removeAvailableModules removed in Rspack v2
     removeEmptyChunks(value: RspackOptimization['removeEmptyChunks']): this;
     mergeDuplicateChunks(
       value: RspackOptimization['mergeDuplicateChunks'],

--- a/packages/bundler-shared/package.json
+++ b/packages/bundler-shared/package.json
@@ -130,7 +130,7 @@
   },
   "dependencies": {
     "@kmijs/shared": "workspace:*",
-    "@rspack/core": "1.6.8",
+    "@rspack/core": "^2.0.0",
     "@swc/helpers": "0.5.15",
     "es5-imcompatible-versions": "^0.1.78",
     "esbuild": "0.17.19",
@@ -140,7 +140,7 @@
   },
   "devDependencies": {
     "@polka/compression": "1.0.0-next.25",
-    "@rspack/lite-tapable": "1.0.1",
+    "@rspack/lite-tapable": "1.1.0",
     "@types/express": "4.17.17",
     "@types/less": "3.0.3",
     "compression": "1.7.4",
@@ -154,7 +154,7 @@
     "tapable": "2.2.1"
   },
   "engines": {
-    "node": "^14.18.0 || >=16.10.0"
+    "node": ">=20.19.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-bundler/package.json
+++ b/packages/preset-bundler/package.json
@@ -41,7 +41,7 @@
     "@kmijs/plugin-svgr": "workspace:*",
     "@kmijs/shared": "workspace:*",
     "@kmijs/types": "workspace:*",
-    "@rspack/plugin-react-refresh": "^1.0.1",
+    "@rspack/plugin-react-refresh": "^2.0.0",
     "core-js": "3.28.0",
     "react-refresh": "0.14.0"
   },
@@ -50,7 +50,7 @@
     "umi": "^4.4.11"
   },
   "engines": {
-    "node": ">=16.10.0"
+    "node": ">=20.19.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/preset-bundler/src/features/react/react.test.ts
+++ b/packages/preset-bundler/src/features/react/react.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest'
+
+describe('ReactRefreshRspackPlugin v2 named import', () => {
+  test('ReactRefreshRspackPlugin is a named export (not default)', async () => {
+    const mod = await import('@rspack/plugin-react-refresh')
+    expect(mod.ReactRefreshRspackPlugin).toBeDefined()
+    expect(typeof mod.ReactRefreshRspackPlugin).toBe('function')
+  })
+})

--- a/packages/preset-bundler/src/features/react/react.ts
+++ b/packages/preset-bundler/src/features/react/react.ts
@@ -51,7 +51,7 @@ export default (api: IApi) => {
       const isDev = api.env === 'development'
       const useFastRefresh = isDev && api.config.fastRefresh !== false
       if (useFastRefresh) {
-        const { default: ReactRefreshRspackPlugin } = await import(
+        const { ReactRefreshRspackPlugin } = await import(
           '@rspack/plugin-react-refresh'
         )
         const SCRIPT_REGEX = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/

--- a/packages/preset-bundler/src/features/rspack/incremental.test.ts
+++ b/packages/preset-bundler/src/features/rspack/incremental.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, vi } from 'vitest'
+import { applyIncremental } from './incremental'
+
+describe('incremental v2 migration', () => {
+  test('uses config.set not config.experiments', () => {
+    const bundlerChainCallbacks: Array<(config: any) => any> = []
+    const mockConfig = {
+      set: vi.fn().mockReturnThis(),
+      experiments: vi.fn().mockReturnThis(),
+    }
+
+    const mockApi = {
+      config: { rspack: { incremental: true } },
+      env: 'development',
+      logger: { info: vi.fn() },
+      bundlerChain: vi.fn((cb: (config: any) => any) =>
+        bundlerChainCallbacks.push(cb),
+      ),
+    }
+
+    applyIncremental(mockApi as any)
+
+    bundlerChainCallbacks.forEach((cb) => cb(mockConfig))
+
+    expect(mockConfig.set).toHaveBeenCalledWith('incremental', true)
+    expect(mockConfig.experiments).not.toHaveBeenCalled()
+  })
+
+  test('does not set incremental when config is disabled', () => {
+    const bundlerChainCallbacks: Array<(config: any) => any> = []
+    const mockConfig = {
+      set: vi.fn().mockReturnThis(),
+      experiments: vi.fn().mockReturnThis(),
+    }
+
+    const mockApi = {
+      config: { rspack: { incremental: false } },
+      env: 'development',
+      logger: { info: vi.fn() },
+      bundlerChain: vi.fn((cb: (config: any) => any) =>
+        bundlerChainCallbacks.push(cb),
+      ),
+    }
+
+    applyIncremental(mockApi as any)
+
+    bundlerChainCallbacks.forEach((cb) => cb(mockConfig))
+
+    expect(mockConfig.set).not.toHaveBeenCalled()
+    expect(mockConfig.experiments).not.toHaveBeenCalled()
+  })
+})

--- a/packages/preset-bundler/src/features/rspack/incremental.ts
+++ b/packages/preset-bundler/src/features/rspack/incremental.ts
@@ -4,10 +4,7 @@ export function applyIncremental(api: IApi) {
   api.bundlerChain((config) => {
     if (api.config.rspack?.incremental && api.env === 'development') {
       api.logger.info('Rspack incremental is enabled')
-      config.experiments({
-        ...config.toConfig().experiments,
-        incremental: api.env === 'development',
-      })
+      config.set('incremental', api.env === 'development')
     }
     return config
   })

--- a/packages/preset-bundler/src/features/rspack/lazyCompilation.test.ts
+++ b/packages/preset-bundler/src/features/rspack/lazyCompilation.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test, vi } from 'vitest'
+import { applyLazyCompilation } from './lazyCompilation'
+
+describe('lazyCompilation v2 migration', () => {
+  test('uses config.set not config.experiments', () => {
+    const bundlerChainCallbacks: Array<(config: any) => any> = []
+    const mockConfig = {
+      set: vi.fn().mockReturnThis(),
+      experiments: vi.fn().mockReturnThis(),
+    }
+
+    const mockApi = {
+      config: { rspack: { lazyCompilation: true } },
+      env: 'development',
+      logger: { info: vi.fn() },
+      bundlerChain: vi.fn((cb: (config: any) => any) =>
+        bundlerChainCallbacks.push(cb),
+      ),
+    }
+
+    applyLazyCompilation(mockApi as any)
+
+    bundlerChainCallbacks.forEach((cb) => cb(mockConfig))
+
+    expect(mockConfig.set).toHaveBeenCalledWith(
+      'lazyCompilation',
+      expect.objectContaining({
+        test: expect.any(Function),
+      }),
+    )
+    expect(mockConfig.experiments).not.toHaveBeenCalled()
+  })
+
+  test('does not set lazyCompilation when config is disabled', () => {
+    const bundlerChainCallbacks: Array<(config: any) => any> = []
+    const mockConfig = {
+      set: vi.fn().mockReturnThis(),
+      experiments: vi.fn().mockReturnThis(),
+    }
+
+    const mockApi = {
+      config: { rspack: { lazyCompilation: false } },
+      env: 'development',
+      logger: { info: vi.fn() },
+      bundlerChain: vi.fn((cb: (config: any) => any) =>
+        bundlerChainCallbacks.push(cb),
+      ),
+    }
+
+    applyLazyCompilation(mockApi as any)
+
+    bundlerChainCallbacks.forEach((cb) => cb(mockConfig))
+
+    expect(mockConfig.set).not.toHaveBeenCalled()
+    expect(mockConfig.experiments).not.toHaveBeenCalled()
+  })
+})

--- a/packages/preset-bundler/src/features/rspack/lazyCompilation.ts
+++ b/packages/preset-bundler/src/features/rspack/lazyCompilation.ts
@@ -4,16 +4,13 @@ export function applyLazyCompilation(api: IApi) {
   api.bundlerChain((config) => {
     if (api.config.rspack?.lazyCompilation && api.env === 'development') {
       api.logger.info('Rspack Lazy compilation is enabled')
-      config.experiments({
-        ...config.toConfig().experiments,
-        lazyCompilation: {
-          test(module: any) {
-            // prevent dev-client.js from being lazy compiled
-            const isMyClient = module
-              .nameForCondition()
-              .endsWith('client/client.js')
-            return !isMyClient
-          },
+      config.set('lazyCompilation', {
+        test(module: any) {
+          // prevent dev-client.js from being lazy compiled
+          const isMyClient = module
+            .nameForCondition()
+            .endsWith('client/client.js')
+          return !isMyClient
         },
       })
     }

--- a/packages/preset-bundler/src/features/rspack/rspack.ts
+++ b/packages/preset-bundler/src/features/rspack/rspack.ts
@@ -83,9 +83,9 @@ export default (api: IApi) => {
   })
 
   api.onBuildComplete(({ err, stats }) => {
-    const hasErrors = stats.hasErrors()
+    const hasErrors = stats?.hasErrors() || false
     if (!err && !hasErrors) {
-      const statsJson = stats.toJson({
+      const statsJson = stats!.toJson({
         children: true,
         moduleTrace: true,
         timings: true,

--- a/packages/preset-bundler/src/features/rspack/rspack.ts
+++ b/packages/preset-bundler/src/features/rspack/rspack.ts
@@ -111,6 +111,82 @@ export default (api: IApi) => {
     if (process.env.LOCK_CORE_JS !== 'none') {
       memo.resolve.alias.set('core-js', CORE_JS_DIR)
     }
+
+    // 修复 Rspack v2 已移除的 output 选项兼容性问题
+    // 这些选项在 Rspack v2 中已移动或移除，需要自动转换以避免构建失败
+    const libraryTarget = memo.output.get('libraryTarget') as string | undefined
+    if (libraryTarget) {
+      const library = memo.output.get('library') as
+        | string
+        | { name?: string; type?: string }
+        | undefined
+      memo.output.delete('libraryTarget')
+
+      if (typeof library === 'string') {
+        memo.output.library({
+          name: library,
+          type: libraryTarget,
+        })
+      } else if (library && typeof library === 'object' && !library.type) {
+        memo.output.library({
+          ...library,
+          type: libraryTarget,
+        })
+      }
+    }
+
+    const libraryExport = memo.output.get('libraryExport') as
+      | string
+      | string[]
+      | undefined
+    if (libraryExport) {
+      const library = memo.output.get('library') as any
+      memo.output.delete('libraryExport')
+      if (typeof library === 'object' && library) {
+        memo.output.library({
+          ...library,
+          export: libraryExport,
+        })
+      }
+    }
+
+    const umdNamedDefine = memo.output.get('umdNamedDefine') as
+      | boolean
+      | undefined
+    if (umdNamedDefine !== undefined) {
+      const library = memo.output.get('library') as any
+      memo.output.delete('umdNamedDefine')
+      if (typeof library === 'object' && library) {
+        memo.output.library({
+          ...library,
+          umdNamedDefine,
+        })
+      }
+    }
+
+    const auxiliaryComment = memo.output.get('auxiliaryComment') as
+      | string
+      | { before?: string; after?: string }
+      | undefined
+    if (auxiliaryComment) {
+      const library = memo.output.get('library') as any
+      memo.output.delete('auxiliaryComment')
+      if (typeof library === 'object' && library) {
+        memo.output.library({
+          ...library,
+          auxiliaryComment,
+        })
+      }
+    }
+
+    if (memo.output.has('charset')) {
+      memo.output.delete('charset')
+    }
+
+    if (memo.optimization.has('removeAvailableModules')) {
+      memo.optimization.delete('removeAvailableModules')
+    }
+
     return memo
   })
 

--- a/packages/preset-bundler/src/features/transformImport/transformImport.test.ts
+++ b/packages/preset-bundler/src/features/transformImport/transformImport.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+
+describe('transformImport v2 migration', () => {
+  test('modifySwcLoaderOptions uses memo.transformImport not rspackExperiments.import', () => {
+    const memo: Record<string, any> = {}
+
+    const transformImport = [
+      { libraryName: 'antd', libraryDirectory: 'lib' },
+      { libraryName: 'lodash', camelToDashComponentName: true },
+    ]
+
+    memo.transformImport ??= []
+    memo.transformImport.push(...transformImport)
+
+    expect(memo.transformImport).toHaveLength(2)
+    expect(memo.transformImport[0].libraryName).toBe('antd')
+    expect(memo.transformImport[1].libraryName).toBe('lodash')
+    expect(memo.rspackExperiments).toBeUndefined()
+  })
+
+  test('memo.transformImport initializes empty array when not set', () => {
+    const memo: Record<string, any> = {}
+
+    memo.transformImport ??= []
+
+    expect(Array.isArray(memo.transformImport)).toBe(true)
+    expect(memo.transformImport).toHaveLength(0)
+  })
+})

--- a/packages/preset-bundler/src/features/transformImport/transformImport.ts
+++ b/packages/preset-bundler/src/features/transformImport/transformImport.ts
@@ -122,9 +122,8 @@ export default (api: IApi) => {
   api.modifySwcLoaderOptions((memo) => {
     const { transformImport } = api.config
     if (transformImport) {
-      memo.rspackExperiments ??= {}
-      memo.rspackExperiments.import ??= []
-      memo.rspackExperiments.import.push(...transformImport)
+      memo.transformImport ??= []
+      memo.transformImport.push(...transformImport)
     }
     return memo
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -742,8 +742,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@rspack/core':
-        specifier: 1.6.8
-        version: 1.6.8(@swc/helpers@0.5.15)
+        specifier: ^2.0.0
+        version: 2.0.1(@swc/helpers@0.5.15)
       '@swc/helpers':
         specifier: 0.5.15
         version: 0.5.15
@@ -767,8 +767,8 @@ importers:
         specifier: 1.0.0-next.25
         version: 1.0.0-next.25
       '@rspack/lite-tapable':
-        specifier: 1.0.1
-        version: 1.0.1
+        specifier: 1.1.0
+        version: 1.1.0
       '@types/express':
         specifier: 4.17.17
         version: 4.17.17
@@ -1008,8 +1008,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@rspack/plugin-react-refresh':
-        specifier: ^1.0.1
-        version: 1.4.3(react-refresh@0.14.0)
+        specifier: ^2.0.0
+        version: 2.0.0(react-refresh@0.14.0)
       core-js:
         specifier: 3.28.0
         version: 3.28.0
@@ -5448,12 +5448,29 @@ packages:
       - '@algolia/client-search'
     dev: true
 
+  /@emnapi/core@1.10.0:
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+    requiresBuild: true
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    dev: false
+    optional: true
+
   /@emnapi/core@1.7.1:
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
     requiresBuild: true
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
       tslib: 2.8.1
+    optional: true
+
+  /@emnapi/runtime@1.10.0:
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+    requiresBuild: true
+    dependencies:
+      tslib: 2.8.1
+    dev: false
     optional: true
 
   /@emnapi/runtime@1.7.1:
@@ -5468,6 +5485,14 @@ packages:
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  /@emnapi/wasi-threads@1.2.1:
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+    requiresBuild: true
+    dependencies:
+      tslib: 2.8.1
+    dev: false
     optional: true
 
   /@emotion/babel-plugin@11.13.5:
@@ -6394,40 +6419,14 @@ packages:
     resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
     dev: true
 
-  /@module-federation/error-codes@0.21.6:
-    resolution: {integrity: sha512-MLJUCQ05KnoVl8xd6xs9a5g2/8U+eWmVxg7xiBMeR0+7OjdWUbHwcwgVFatRIwSZvFgKHfWEiI7wsU1q1XbTRQ==}
-    dev: false
-
   /@module-federation/error-codes@0.8.12:
     resolution: {integrity: sha512-K+F4iiV62KY+IpjK6ggn3vI5Yt/T/LUb6xuazY78bhAGwLaHe1DYr7BfSutKMpiB+Dcs6U4dYOBogSMnnl0j4Q==}
-
-  /@module-federation/runtime-core@0.21.6:
-    resolution: {integrity: sha512-5Hd1Y5qp5lU/aTiK66lidMlM/4ji2gr3EXAtJdreJzkY+bKcI5+21GRcliZ4RAkICmvdxQU5PHPL71XmNc7Lsw==}
-    dependencies:
-      '@module-federation/error-codes': 0.21.6
-      '@module-federation/sdk': 0.21.6
-    dev: false
 
   /@module-federation/runtime-core@0.6.20:
     resolution: {integrity: sha512-rX7sd/i7tpkAbfMD4TtFt/57SWNC/iv7UYS8g+ad7mnCJggWE1YEKsKSFgcvp4zU3thwR+j2y+kOCwd1sQvxEA==}
     dependencies:
       '@module-federation/error-codes': 0.8.12
       '@module-federation/sdk': 0.8.12
-
-  /@module-federation/runtime-tools@0.21.6:
-    resolution: {integrity: sha512-fnP+ZOZTFeBGiTAnxve+axGmiYn2D60h86nUISXjXClK3LUY1krUfPgf6MaD4YDJ4i51OGXZWPekeMe16pkd8Q==}
-    dependencies:
-      '@module-federation/runtime': 0.21.6
-      '@module-federation/webpack-bundler-runtime': 0.21.6
-    dev: false
-
-  /@module-federation/runtime@0.21.6:
-    resolution: {integrity: sha512-+caXwaQqwTNh+CQqyb4mZmXq7iEemRDrTZQGD+zyeH454JAYnJ3s/3oDFizdH6245pk+NiqDyOOkHzzFQorKhQ==}
-    dependencies:
-      '@module-federation/error-codes': 0.21.6
-      '@module-federation/runtime-core': 0.21.6
-      '@module-federation/sdk': 0.21.6
-    dev: false
 
   /@module-federation/runtime@0.8.12:
     resolution: {integrity: sha512-eYohRfambj/qzxz6tEakDn459ROcixWO4zL5gmTEOmwG+jCDnxGR14j1guopyrrpjb6EKFNrPVWtYZTPPfGdQQ==}
@@ -6436,21 +6435,10 @@ packages:
       '@module-federation/runtime-core': 0.6.20
       '@module-federation/sdk': 0.8.12
 
-  /@module-federation/sdk@0.21.6:
-    resolution: {integrity: sha512-x6hARETb8iqHVhEsQBysuWpznNZViUh84qV2yE7AD+g7uIzHKiYdoWqj10posbo5XKf/147qgWDzKZoKoEP2dw==}
-    dev: false
-
   /@module-federation/sdk@0.8.12:
     resolution: {integrity: sha512-zFgXYBHbzwIqlrLfn6ewIRXDZCctDDQT2nFhbsZr29yWQgpmW1fm2kJCxQsG0DENGGN1KpzfDoxjjvSKJS/ZHA==}
     dependencies:
       isomorphic-rslog: 0.0.7
-
-  /@module-federation/webpack-bundler-runtime@0.21.6:
-    resolution: {integrity: sha512-7zIp3LrcWbhGuFDTUMLJ2FJvcwjlddqhWGxi/MW3ur1a+HaO8v5tF2nl+vElKmbG1DFLU/52l3PElVcWf/YcsQ==}
-    dependencies:
-      '@module-federation/runtime': 0.21.6
-      '@module-federation/sdk': 0.21.6
-    dev: false
 
   /@module-federation/webpack-bundler-runtime@0.8.12:
     resolution: {integrity: sha512-zd343RO7/R7Xjh5ym5KdnYQ70z4LBmMxWsa44FS0nyNv04sOq6V1eZSCGKbEhbfqqhbS5Wfj8OzJyedeVvV/OQ==}
@@ -6619,16 +6607,6 @@ packages:
     dev: false
     optional: true
 
-  /@napi-rs/wasm-runtime@1.0.7:
-    resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
-    requiresBuild: true
-    dependencies:
-      '@emnapi/core': 1.7.1
-      '@emnapi/runtime': 1.7.1
-      '@tybys/wasm-util': 0.10.1
-    dev: false
-    optional: true
-
   /@napi-rs/wasm-runtime@1.1.0:
     resolution: {integrity: sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA==}
     requiresBuild: true
@@ -6637,6 +6615,19 @@ packages:
       '@emnapi/runtime': 1.7.1
       '@tybys/wasm-util': 0.10.1
     dev: true
+    optional: true
+
+  /@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    requiresBuild: true
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    dev: false
     optional: true
 
   /@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1:
@@ -7790,114 +7781,117 @@ packages:
     dev: true
     optional: true
 
-  /@rspack/binding-darwin-arm64@1.6.8:
-    resolution: {integrity: sha512-e8CTQtzaeGnf+BIzR7wRMUwKfIg0jd/sxMRc1Vd0bCMHBhSN9EsGoMuJJaKeRrSmy2nwMCNWHIG+TvT1CEKg+A==}
+  /@rspack/binding-darwin-arm64@2.0.1:
+    resolution: {integrity: sha512-CGFO5zmajD1Itch1lxAI7+gvKiagzyqXopHv/jHG9Su2WWQ2/Nhn2/rkSpdp6ptE9ri6+6tCOOahf099/v/Xog==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rspack/binding-darwin-x64@1.6.8:
-    resolution: {integrity: sha512-ku1XpTEPt6Za11zhpFWhfwrTQogcgi9RJrOUVC4FESiPO9aKyd4hJ+JiPgLY0MZOqsptK6vEAgOip+uDVXrCpg==}
+  /@rspack/binding-darwin-x64@2.0.1:
+    resolution: {integrity: sha512-2vvBNBoS09/PurupBwSrlTZd8283o00B8v20ncsNUdEff41uCR/hzIrYoTIVWnVST+Gt5O1+cfcfORp397lajg==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rspack/binding-linux-arm64-gnu@1.6.8:
-    resolution: {integrity: sha512-fvZX6xZPvBT8qipSpvkKMX5M7yd2BSpZNCZXcefw6gA3uC7LI3gu+er0LrDXY1PtPzVuHTyDx+abwWpagV3PiQ==}
+  /@rspack/binding-linux-arm64-gnu@2.0.1:
+    resolution: {integrity: sha512-uvNXk6ahE3AH3h2avnd1Mgno68YQpS4cfX1OkOGWIC/roL+NrOP2XVXV4yfVAoydPALDO7AfbIfN0QdmBK3rsA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rspack/binding-linux-arm64-musl@1.6.8:
-    resolution: {integrity: sha512-++XMKcMNrt59HcFBLnRaJcn70k3X0GwkAegZBVpel8xYIAgvoXT5+L8P1ExId/yTFxqedaz8DbcxQnNmMozviw==}
+  /@rspack/binding-linux-arm64-musl@2.0.1:
+    resolution: {integrity: sha512-S/a6uN9PiZ5O/PjSqyIXhuRC1lVzeJkJV69NeLk5sIEUiDQ/aQGZG97uN+tluwpbo1tPbLJkdHYETfjspOX4Pg==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rspack/binding-linux-x64-gnu@1.6.8:
-    resolution: {integrity: sha512-tv3BWkTE1TndfX+DsE1rSTg8fBevCxujNZ3MlfZ22Wfy9x1FMXTJlWG8VIOXmaaJ1wUHzv8S7cE2YUUJ2LuiCg==}
+  /@rspack/binding-linux-x64-gnu@2.0.1:
+    resolution: {integrity: sha512-C13Kk0OkZiocZVj187Sf753UH6pDXnuEu6vzUvi3qv9ltibG1ki0H2Y8isXBYL2cHQOV+hk0g1S6/4z3TTB97A==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rspack/binding-linux-x64-musl@1.6.8:
-    resolution: {integrity: sha512-DCGgZ5/in1O3FjHWqXnDsncRy+48cMhfuUAAUyl0yDj1NpsZu9pP+xfGLvGcQTiYrVl7IH9Aojf1eShP/77WGA==}
+  /@rspack/binding-linux-x64-musl@2.0.1:
+    resolution: {integrity: sha512-TQsiBFpEDGkuvK9tNdGj/Uc+AIytzqhxXH/1jKU6M24cWB1DTw/Cx7DdrkCBDyq3129K3POLdujvbWCGqBzQUw==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rspack/binding-wasm32-wasi@1.6.8:
-    resolution: {integrity: sha512-VUwdhl/lI4m6o1OGCZ9JwtMjTV/yLY5VZTQdEPKb40JMTlmZ5MBlr5xk7ByaXXYHr6I+qnqEm73iMKQvg6iknw==}
+  /@rspack/binding-wasm32-wasi@2.0.1:
+    resolution: {integrity: sha512-wk3gyUgBW/ayP49bI54bkY8+EQnfBHxdoe9dz3oobSTZQc8AOWwmUUDEPltW8rUvPOM6dfHECTOUMnfaf2f5yA==}
     cpu: [wasm32]
     requiresBuild: true
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.7
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     dev: false
     optional: true
 
-  /@rspack/binding-win32-arm64-msvc@1.6.8:
-    resolution: {integrity: sha512-23YX7zlOZlub+nPGDBUzktb4D5D6ETUAluKjXEeHIZ9m7fSlEYBnGL66YE+3t1DHXGd0OqsdwlvrNGcyo6EXDQ==}
+  /@rspack/binding-win32-arm64-msvc@2.0.1:
+    resolution: {integrity: sha512-rHjLcy3VcAC3+x+PxH+gwhwv6tPe0JdXTNT5eAOs9wgZIM6T9p4wre49+K4Qy98+Fb7TTbLX0ObUitlOkGwTSA==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rspack/binding-win32-ia32-msvc@1.6.8:
-    resolution: {integrity: sha512-cFgRE3APxrY4AEdooVk2LtipwNNT/9mrnjdC5lVbsIsz+SxvGbZR231bxDJEqP15+RJOaD07FO1sIjINFqXMEg==}
+  /@rspack/binding-win32-ia32-msvc@2.0.1:
+    resolution: {integrity: sha512-Ad1vVqMBBnd4T8rsORngu9sl2kyRTlS4kMlvFudjzl1X2UFArEDBe0YVGNN7ZvahM12CErUx2WiN8Sd8pb+qXQ==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rspack/binding-win32-x64-msvc@1.6.8:
-    resolution: {integrity: sha512-cIuhVsZYd3o3Neo1JSAhJYw6BDvlxaBoqvgwRkG1rs0ExFmEmgYyG7ip9pFKnKNWph/tmW3rDYypmEfjs1is7g==}
+  /@rspack/binding-win32-x64-msvc@2.0.1:
+    resolution: {integrity: sha512-oPM2Jtm7HOlmxl/aBfleAVlL6t9VeHx6WvEets7BBJMInemFXAQd4CErRqybf7rXutACzLeUWBOue4Jpd1/ykw==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rspack/binding@1.6.8:
-    resolution: {integrity: sha512-lUeL4mbwGo+nqRKqFDCm9vH2jv9FNMVt1X8jqayWRcOCPlj/2UVMEFgqjR7Pp2vlvnTKq//31KbDBJmDZq31RQ==}
+  /@rspack/binding@2.0.1:
+    resolution: {integrity: sha512-ynV1gw4KqFtQ0P+ZZh76SUj49wBb2FuHW3zSmHverHWuxBhzvrZS6/dZ+fCFQG8bTTPtrPz0RQUTN3uEDbPVBQ==}
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.6.8
-      '@rspack/binding-darwin-x64': 1.6.8
-      '@rspack/binding-linux-arm64-gnu': 1.6.8
-      '@rspack/binding-linux-arm64-musl': 1.6.8
-      '@rspack/binding-linux-x64-gnu': 1.6.8
-      '@rspack/binding-linux-x64-musl': 1.6.8
-      '@rspack/binding-wasm32-wasi': 1.6.8
-      '@rspack/binding-win32-arm64-msvc': 1.6.8
-      '@rspack/binding-win32-ia32-msvc': 1.6.8
-      '@rspack/binding-win32-x64-msvc': 1.6.8
+      '@rspack/binding-darwin-arm64': 2.0.1
+      '@rspack/binding-darwin-x64': 2.0.1
+      '@rspack/binding-linux-arm64-gnu': 2.0.1
+      '@rspack/binding-linux-arm64-musl': 2.0.1
+      '@rspack/binding-linux-x64-gnu': 2.0.1
+      '@rspack/binding-linux-x64-musl': 2.0.1
+      '@rspack/binding-wasm32-wasi': 2.0.1
+      '@rspack/binding-win32-arm64-msvc': 2.0.1
+      '@rspack/binding-win32-ia32-msvc': 2.0.1
+      '@rspack/binding-win32-x64-msvc': 2.0.1
     dev: false
 
-  /@rspack/core@1.6.8(@swc/helpers@0.5.15):
-    resolution: {integrity: sha512-FolcIAH5FW4J2FET+qwjd1kNeFbCkd0VLuIHO0thyolEjaPSxw5qxG67DA7BZGm6PVcoiSgPLks1DL6eZ8c+fA==}
-    engines: {node: '>=18.12.0'}
+  /@rspack/core@2.0.1(@swc/helpers@0.5.15):
+    resolution: {integrity: sha512-lgfZiExh8kDR/3obgi3RQKwKG5av1Xf5qDN1aVde777W9pbmx0Pqvrww1qtNvJ+gobEjbrrn5HEZWYGe0VLmcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
       '@swc/helpers': '>=0.5.1'
     peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
       '@swc/helpers':
         optional: true
     dependencies:
-      '@module-federation/runtime-tools': 0.21.6
-      '@rspack/binding': 1.6.8
-      '@rspack/lite-tapable': 1.1.0
+      '@rspack/binding': 2.0.1
       '@swc/helpers': 0.5.15
     dev: false
 
@@ -7908,19 +7902,17 @@ packages:
 
   /@rspack/lite-tapable@1.1.0:
     resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
-    dev: false
+    dev: true
 
-  /@rspack/plugin-react-refresh@1.4.3(react-refresh@0.14.0):
-    resolution: {integrity: sha512-wZx4vWgy5oMEvgyNGd/oUKcdnKaccYWHCRkOqTdAPJC3WcytxhTX+Kady8ERurSBiLyQpoMiU3Iyd+F1Y2Arbw==}
+  /@rspack/plugin-react-refresh@2.0.0(react-refresh@0.14.0):
+    resolution: {integrity: sha512-Cf6CxBStNDJbiXMc/GmsvG1G8PRlUpa0MSfWsMTI+e8npzuTN/p8nwLs3shriBZOLciqgkSZpBtPTd10BLpj1g==}
     peerDependencies:
+      '@rspack/core': ^2.0.0-0
       react-refresh: '>=0.10.0 <1.0.0'
-      webpack-hot-middleware: 2.x
     peerDependenciesMeta:
-      webpack-hot-middleware:
+      '@rspack/core':
         optional: true
     dependencies:
-      error-stack-parser: 2.1.4
-      html-entities: 2.6.0
       react-refresh: 0.14.0
     dev: false
 
@@ -11736,9 +11728,6 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependenciesMeta:
-      ajv:
-        optional: true
     dependencies:
       ajv: 8.17.1
     dev: true
@@ -15308,12 +15297,6 @@ packages:
     dependencies:
       stackframe: 1.3.4
 
-  /error-stack-parser@2.1.4:
-    resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
-    dependencies:
-      stackframe: 1.3.4
-    dev: false
-
   /es-abstract@1.23.9:
     resolution: {integrity: sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==}
     engines: {node: '>= 0.4'}
@@ -17491,10 +17474,6 @@ packages:
 
   /html-entities@2.1.0:
     resolution: {integrity: sha512-u+OHVGMH5P1HlaTFp3M4HolRnWepgx5rAnYBo+7/TrBZahuJjgQ4TMv2GjQ4IouGDzkgXYeOI/NQuF95VOUOsQ==}
-
-  /html-entities@2.6.0:
-    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
-    dev: false
 
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -26,7 +26,7 @@ export default defineWorkspace([
       setupFiles: ['./scripts/vitest.setup.ts'],
     },
     esbuild: {
-      target: 'node18',
+      target: 'node20',
     },
   },
 ])


### PR DESCRIPTION
## Summary
Upgrade KMI's underlying bundler from Rspack 1.x to Rspack 2.0, bringing performance improvements, a modern API design, and the latest upstream bug fixes.
A user-facing migration guide is provided at `docs/docs/guide/upgrade-v2.md`. For most KMI users who use standard configuration, this upgrade is transparent — no config changes are required.
## Breaking Changes
- **Node.js >= 20.19.0** is now required (Rspack 2.0 drops support for Node 16/18)
## Changes
### Dependency Upgrades
| Package | Old | New |
|---------|-----|-----|
| `@rspack/core` | `1.6.8` | `^2.0.0` |
| `@rspack/plugin-react-refresh` | `^1.0.1` | `^2.0.0` |
| `@rspack/lite-tapable` | `1.0.1` | `1.1.0` |
### Config Migration
- `experiments.lazyCompilation` → top-level `lazyCompilation`
- `experiments.incremental` → top-level `incremental`
- `experiments.outputModule` / `topLevelAwait` / `nativeWatcher` → replaced by `output.module()`, removed defaults
- `swc-loader` `rspackExperiments.import` → `transformImport`
### API Updates
- `ProgressPlugin` handler: 3rd argument changed from `string[]` to `{ builtModules, moduleIdentifier }`
- `RuntimePublicPathPlugin`: `module.constructorName` → `module.constructor.name`
- `ReactRefreshRspackPlugin`: default import → named import (ESM package)
### Types
- Removed `profile` and `removeAvailableModules` from `rspack-chain` types (removed in Rspack v2)
- `SwcLoaderOptions` is now a discriminated union; explicit generics used for `deepmerge`
### Docs
- Added `docs/docs/guide/upgrade-v2.md`: comprehensive migration guide for KMI users
- Updated `docs/docs/guide/rspack.md`: Node version warning, migration link, URL corrections
## Test
Test Files  29 passed | 4 pre-existing failures
     Tests  153 passed | 4 pre-existing failures
- 5 new test files (9 test cases) covering all migration points
- Type check (`pnpm typecheck`): zero errors
- 24/25 rspack build fixtures pass
## Known Issues (Pre-existing)
| Issue | Root Cause |
|-------|-----------|
| `build css-modules-auto` fixture fails | `@kmijs/swc-plugin-auto-css-modules` needs recompilation for swc_core 65.0.1 |
| E2E tests fail on Node 24 | `umi@4.4.11` → `spdy` → `http-deceiver` requires `http_parser` which was removed in Node 24 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Minimum Node.js requirement raised to >=20.19.0 (or >=22.12.0)
  * Rspack v2 migration removes/changes several legacy options and experiment flags

* **Documentation**
  * Added comprehensive Rspack v2 upgrade guide; updated links and compatibility notes

* **Behavior**
  * Progress reporting shape updated (details payload now a structured object)
  * Fast-refresh plugin now loaded via named export

* **Tests**
  * Added unit tests covering migration behaviors and progress callback handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->